### PR TITLE
Adding embedded viewer component for the Universal Viewer

### DIFF
--- a/app/components/universal_viewer.html.erb
+++ b/app/components/universal_viewer.html.erb
@@ -1,0 +1,9 @@
+
+<div>
+
+<iframe
+  src="<%= uv_host %>/uv/uv.html#?manifest=<%= manifest_url %>&config=<%= uv_config_host %>/uv/uv_config.json&m=0&cv=0"
+  title="Digital content viewer" width="900" height="640" allowfullscreen frameborder="0">
+</iframe>
+
+</div>

--- a/app/components/universal_viewer.rb
+++ b/app/components/universal_viewer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+class UniversalViewer < ViewComponent::Base
+
+  def initialize(document:, presenter:, **kwargs)
+    super
+
+    @document = document
+    @presenter = presenter
+  end
+
+  def render?
+    resources.any?
+  end
+
+  def manifest_url
+    @resources&.first&.href
+  end
+
+  def resources
+    @resources ||= @document.digital_objects || []
+  end
+
+  def uv_host
+    ENV['UV_HOST']
+  end
+
+  def uv_config_host
+    ENV['UV_CONFIG_HOST']
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -75,7 +75,7 @@ class CatalogController < ApplicationController
     config.show.document_component = Arclight::DocumentComponent
     config.show.sidebar_component = Arclight::SidebarComponent
     config.show.breadcrumb_component = Arclight::BreadcrumbsHierarchyComponent
-    config.show.embed_component = Arclight::EmbedComponent
+    config.show.embed_component = UniversalViewer
     config.show.access_component = Arclight::AccessComponent
     config.show.online_status_component = Arclight::OnlineStatusIndicatorComponent
     config.show.display_type_field = 'level_ssm'


### PR DESCRIPTION
Adding an embedded viewer, in the form of a [ViewComponent](https://viewcomponent.org/), to handle the display and initialization of the Universal Viewer for digital content links.