### PR TITLE
Ead config changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,14 +36,14 @@ services:
       - redis
       - db
       - solr
-    command: sh -c 'bundle exec sidekiq'
+    command: sh -c 'bundle exec sidekiq -c10'
 
   redis:
-    image: bitnami/redis:6.2
+    image: bitnamilegacy/redis:6.2
     env_file:
       - .docker.env
     volumes:
-      - redis:/bitnami/redis/data
+      - redis:/bitnamilegacy/redis/data
 
   db:
     platform: linux/amd64

--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -26,6 +26,8 @@ settings do
   # provide 'parent' # the immediate parent component (or collection) indexing context
   # provide 'counter' # a global component counter to provide a global sort order for nested components
   # provide 'depth' # the current nesting depth of the component
+  provide 'solr_writer.thread_pool', '0'
+  provide 'processing_thread_pool', '0'
   provide 'component_traject_config', __FILE__
   provide 'date_normalizer', 'Arclight::NormalizedDate'
   provide 'title_normalizer', 'Arclight::NormalizedTitle'

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -59,6 +59,8 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
 ].freeze
 
 settings do
+  provide 'solr_writer.thread_pool', '0'
+  provide 'processing_thread_pool', '0'
   provide 'component_traject_config', File.join(__dir__, 'ead2_component_config.rb')
   provide 'id_normalizer', 'Arclight::NormalizedId'
   provide 'date_normalizer', 'Arclight::NormalizedDate'


### PR DESCRIPTION
Disabling thread pooling in Traject.  We will control concurrent processing in the Sidekiq queues.

Also changes docker compose file to switch to Bitnami legacy images and double the Sidekiq concurrency to 10.