### PR TITLE
Job param fixes

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -18,14 +18,14 @@ class AdminController < ApplicationController
   def index_repository
     repository = params[:repository]
     # EadProcessor.delay.import_eads({ files: [repository] })
-    IndexRepoJob.perform_async({ files: [repository] })
+    IndexRepoJob.perform_async({ 'files'=> [repository] })
     redirect_to admin_path, notice: 'These files are being indexed in the background and will be ready soon.'
   end
 
   def index_ead
     repository = params[:repository]
     file = params[:ead]
-    args = { ead: file, repository: repository }
+    args = { 'ead'=> file, 'repository'=> repository }
     # EadProcessor.delay.index_single_ead(args)
     IndexSingleEadJob.perform_async(args)
     redirect_to admin_path, notice: 'The file is being indexed in the background and will be ready soon.'

--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -52,7 +52,7 @@ class EadProcessor
       ext = File.extname(file_name)
       next unless ext == '.xml'
 
-      args = { ead: file, repository: repository }
+      args = { 'ead'=> file, 'repository'=> repository }
       EadProcessor.index_single_ead(args)
     end
   end
@@ -87,8 +87,8 @@ class EadProcessor
   # need to unzip parent and index only the file selected
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def self.index_single_ead(args = {})
-    repository = args[:repository]
-    file_name = args[:ead]
+    repository = args['repository']
+    file_name = args['ead']
     link = client(args) + "#{repository}/#{file_name}"
     directory = repository.parameterize.underscore
     path = "./data/#{directory}"

--- a/lib/tasks/delete_ead.rake
+++ b/lib/tasks/delete_ead.rake
@@ -11,15 +11,11 @@ namespace :archives_online do
 
     puts "archives_online-Arclight deleting #{ENV['FILE']}...\n"
 
-    if Rails.env == 'development'
-      solr_url = 'http://localhost:8983/solr/blacklight-core'
-    else
-      solr_url = begin
-                  Blacklight.default_index.connection.base_uri.to_s
-                rescue StandardError
-                  ENV['SOLR_URL'] || 'http://localhost:8983/solr/blacklight-core'
-                end
-    end
+    solr_url = begin
+             Blacklight.default_index.connection.base_uri.to_s
+             rescue StandardError
+               ENV['SOLR_URL'] || 'http://localhost:8983/solr/blacklight-core'
+             end
     # one slash per segment only please
     solr_url = solr_url.chomp('/')
 


### PR DESCRIPTION
The passing of params to/from the admin controller, EAD processor, and tasks has been hard to get right.  The problem relates to having to refactor to use Sidekiq/ActiveJob.  Originally, param passing was an inconsistent mix of string and symbol keys, which was okay with Delayed Job, but not okay with AJ because params have to be JSON safe - no symbols or objects.

This fixes all uses of keys to be string literals.  It also found that the delete ead task wouldn't always get the right Solr URL.