### PR TITLE
Fix delete actions on admin page

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -41,7 +41,7 @@
                           <% @delta_eads.each do |d| %>
                             <tr>
                               <td><%= d %></td>                       
-                              <td class="text-right"><%= link_to "Delete", delete_ead_url(ead: d), class: 'btn btn-sm btn-primary', method: :delete, data: { turbo: true, turbo_confirm: "Are you sure?" } %></td>
+                              <td class="text-right"><%= link_to "Delete", delete_ead_url(ead: d), class: 'btn btn-sm btn-primary', data: { turbo: true, turbo_method: :delete, turbo_confirm: "Are you sure?" } %></td>
                             </tr>
                           <% end %>
                         </tbody>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -41,7 +41,7 @@
                           <% @delta_eads.each do |d| %>
                             <tr>
                               <td><%= d %></td>                       
-                              <td class="text-right"><%= link_to "Delete", delete_ead_url(ead: d), class: 'btn btn-sm btn-primary', data: { confirm: "Are you sure?" } %></td>
+                              <td class="text-right"><%= link_to "Delete", delete_ead_url(ead: d), class: 'btn btn-sm btn-primary', method: :delete, data: { turbo: true, turbo_confirm: "Are you sure?" } %></td>
                             </tr>
                           <% end %>
                         </tbody>
@@ -84,7 +84,7 @@
                         <td><%= ead.last_indexed_at&.strftime("%m/%d/%Y at %I:%M%p") %></td>
                         <td>
                           <%= link_to "Index", index_ead_url(repository: repo.repository_id, ead: ead.filename), class: 'btn btn-sm btn-primary' %>
-                          <%= link_to "Delete", delete_ead_url(ead: ead.filename), class: 'btn btn-sm btn-primary', data: { confirm: "Are you sure?" } %>
+                          <%= link_to "Delete", delete_ead_url(ead: ead.filename), class: 'btn btn-sm btn-primary', data: { turbo: true, turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
                         </td>
                       </tr>
                     <% end %>
@@ -128,7 +128,7 @@
                         <% end %>
                       </td>
                       <td>
-                        <%= link_to "Delete", admin_delete_user_path(user), class: 'btn btn-danger btn-sm', method: :delete, data: { turbo: true, turbo_method: :delete, confirm: "Are you sure you want to delete this user?" } %>
+                        <%= link_to "Delete", admin_delete_user_path(user), class: 'btn btn-danger btn-sm', method: :delete, data: { turbo: true, turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this user?" } %>
                         <% if user.role == "admin"%>
                           <%= link_to "Make Manager", admin_update_user_role_path(user), class: 'btn btn-primary btn-sm' %>
                         <% else %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -128,7 +128,7 @@
                         <% end %>
                       </td>
                       <td>
-                        <%= link_to "Delete", admin_delete_user_path(user), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: "Are you sure you want to delete this user?" } %>
+                        <%= link_to "Delete", admin_delete_user_path(user), class: 'btn btn-danger btn-sm', method: :delete, data: { turbo: true, turbo_method: :delete, confirm: "Are you sure you want to delete this user?" } %>
                         <% if user.role == "admin"%>
                           <%= link_to "Make Manager", admin_update_user_role_path(user), class: 'btn btn-primary btn-sm' %>
                         <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
   get 'admin/index_repository', to: 'admin#index_repository', as: 'index_repository'
   get 'admin/index_ead', to: 'admin#index_ead', as: 'index_ead'
-  get 'admin/delete_ead', to: 'admin#delete_ead', as: 'delete_ead'
+    delete 'admin/delete_ead', to: 'admin#delete_ead', as: 'delete_ead'
   delete 'admin/delete_user/:id', to: 'admin#delete_user', as: 'admin_delete_user'
   get 'admin/update_user_role/:id', to: 'admin#update_user_role', as: 'admin_update_user_role'
   get 'admin/edit_repository/:id', to: 'admin#edit_repository', as: 'admin_edit_repository'


### PR DESCRIPTION
We disabled turbo on the admin page in a previous commit because it was breaking the JS tabs. But then that caused several problems that require overrides on `link_to` tags to ensure use of the DELETE verb and to make sure confirmation prompts work.