### PR TITLE
Make catalog controller actions challenged by bot_challenge_page configurable

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -44,6 +44,8 @@ TEST_DB=archives_online_test
 # We have the bot_challenge_page installed, which requires Cloudflare Turnstile account keys
 # Here are the configurable items with their defaults
 CF_BOT_ENABLED=false
+# The actions to protect: currently only relevant to CatalogController
+CF_BOT_ACTIONS="index,show"
 CF_BOT_DURATION=600 # in minutes
 CF_BOT_SITE_KEY=1x00000000000000000000AA # defaults to CF test key
 CF_BOT_SECRET_KEY=1x0000000000000000000000000000000AA # defaults to CF test key

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,7 +8,8 @@ class CatalogController < ApplicationController
   include Arclight::FieldConfigHelpers
   include Ngao::ComponentMetadataHelper
 
-  bot_challenge only: [:index, :show]
+  challenge_actions = ENV['CF_BOT_ACTIONS']&.split(",")&.map(&:to_sym)
+  bot_challenge only: challenge_actions || [:index, :show]
 
   # OVERRIDE v1.4.0 Arclight::Catalog#hierarchy to force large row count for expand_all
   def hierarchy


### PR DESCRIPTION
Adding override via configuration to specify which actions on the CatalogController to protect with CF challenge