### PR TITLE
Fixing date format in sitemap

### DIFF
--- a/lib/tasks/generate_sitemap.rake.hold
+++ b/lib/tasks/generate_sitemap.rake.hold
@@ -18,7 +18,7 @@ namespace :archives_online do
             xml.loc "https://archives.iu.edu/catalog/#{ead_path}"
 
             lastmod = file.last_indexed_at.nil? ? Time.now : file.last_indexed_at.to_time
-            xml.lastmod lastmod.strftime("%Y-%m-%d")
+            xml.lastmod lastmod.strftime("%Y-%m-%dT%H:%M")
           }
         end
       }


### PR DESCRIPTION
The sitemaps spec says it allows for W3C date formats, including a time segment, but it seems like Google specifically doesn't like inclusion of time, so just including the date parts.