### PR TITLE
Fixing nav hierarchy so that components with digital objects are clickable

### DIFF
--- a/app/helpers/ngao/component_metadata_helper.rb
+++ b/app/helpers/ngao/component_metadata_helper.rb
@@ -10,6 +10,7 @@ module Ngao
     # @param blacklight_config [Blacklight::Configuration]
     # @return [Boolean]
     def component_has_extra_metadata?(document, blacklight_config)
+      return true if component_has_digital_objects(document)
       blacklight_config.component_fields.values.any? do |field_config|
         next false if field_is_container?(field_config)
 
@@ -21,6 +22,14 @@ module Ngao
     end
 
     private
+
+    def component_has_digital_objects(document)
+      doc_value = document.digital_objects&.first
+      value_present_and_non_empty?(doc_value)
+    rescue StandardError => e
+      log_field_access_error(document, field_name, e)
+      false
+    end
 
     def field_is_container?(field_config)
       field_config.try(:accessor) == :containers || field_config.try(:field) == :containers


### PR DESCRIPTION
The hierarchy was customized in a way that makes components clickable only when they contain additional fields, per https://github.com/notch8/archives_online/pull/169 .  

However, this made it to where components with digital objects couldn't be accessed.  This adds another check to the helper that decides whether to decorate the component as a link.